### PR TITLE
Add calendar skeleton and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,12 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Documentation
+
+Project analysis for the upcoming calendar feature is available in
+[`docs/calendar-analysis.md`](docs/calendar-analysis.md).
+
+An initial calendar skeleton is available at the `/calendario` route, providing basic view switching and date navigation.
+
 # teste2

--- a/docs/calendar-analysis.md
+++ b/docs/calendar-analysis.md
@@ -1,0 +1,73 @@
+# Calendar Feature Analysis
+
+This document summarizes the current project architecture and how a calendar module can be integrated.
+
+## Project Stack Overview
+
+### Build and Tooling
+- **Bundler:** Vite with TypeScript (`vite.config.ts`)
+- **Scripts:** `npm run dev`, `npm run build`, `npm run lint`
+- **Linting:** ESLint with React and TypeScript presets
+
+### Styling
+- **Component library:** Chakra UI
+- **Utility classes:** Tailwind CSS configured in `src/index.css` but used sparingly
+
+### Routing
+- **Router:** React Router DOM v6
+- **Code splitting:** pages imported via `lazy` and displayed through `Suspense`
+- **Layout:** `src/components/Layout.tsx` provides header and bottom navigation
+
+### State Management
+- Local `useState` and `useEffect` hooks only
+- No global store (Redux, Zustand, etc.)
+
+### API / Data Fetching
+- No backend integration yet; pages contain mock or local data
+
+### Folder Structure
+- `src/pages` – route-based pages (`Entrar`, `Cadastrar`, `Consultas`, etc.)
+- `src/components` – shared UI such as `Layout`
+- `src/assets` – static files
+
+### Responsiveness
+- Chakra's responsive props are used; no custom breakpoints are defined
+- Mobile-first styles via Chakra defaults
+
+### Testing
+- No test configuration; `npm test` script is missing
+
+## Calendar Integration Plan
+
+### Placement
+- Expand the **Consultas** section with a new route, e.g. `/consultas/calendario`
+- Navigation already links to `/consultas`; a nested route keeps the flow consistent
+
+### Components and Structure
+- Create a new folder `src/features/calendar`
+  - `CalendarProvider` for current date/view and drag state
+  - View components: `DailyView`, `WeeklyView`, `MonthlyView`
+  - UI helpers: `ViewSwitcher`, `DateNavigator`, `TimeSlot`, `AppointmentCard`
+  - Optional widgets: `OccupancySummary`, modals for create/edit
+- Components use Chakra UI and follow mobile-first design
+
+### Proposed Dependencies
+- `dayjs` – lightweight date manipulation
+- `@dnd-kit/core` and `@dnd-kit/sortable` – drag & drop interactions
+- `@tanstack/react-query` – fetch and cache appointments
+- `@tanstack/react-virtual` – virtualize long lists (optional)
+
+These libraries integrate well with Chakra UI and keep the bundle light.
+
+### Implementation Notes
+- Mock API endpoints for `/appointments` and `/blocks` during early development
+- Provider should expose hooks like `useCalendar` and `useAppointments`
+- Routes will be updated in `App.tsx` to include the calendar path
+- Start mobile first (375px) and scale up using Chakra's breakpoints
+
+### Next Steps
+1. Install the dependencies above
+2. Implement provider and skeleton views
+3. Fetch mock data with React Query
+4. Add drag & drop logic with `@dnd-kit`
+5. Write basic tests for hooks and components

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "framer-motion": "^12.23.12",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "@tanstack/react-query": "^5.59.15",
+    "@tanstack/react-virtual": "^3.0.0",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^8.0.0",
+    "dayjs": "^1.11.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ const Nova = lazy(() => import('./pages/Consultas/Nova'))
 const Detalhes = lazy(() => import('./pages/Consultas/[id]'))
 const Perfil = lazy(() => import('./pages/Perfil'))
 const Configuracoes = lazy(() => import('./pages/Configuracoes'))
+const Calendario = lazy(() => import('./pages/Calendario'))
 
 const router = createBrowserRouter([
   {
@@ -23,6 +24,7 @@ const router = createBrowserRouter([
       { path: 'consultas/:id', element: <Detalhes /> },
       { path: 'perfil', element: <Perfil /> },
       { path: 'configuracoes', element: <Configuracoes /> },
+      { path: 'calendario', element: <Calendario /> },
     ],
   },
 ])

--- a/src/calendar/CalendarContext.ts
+++ b/src/calendar/CalendarContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react'
+
+export type View = 'daily' | 'weekly' | 'monthly'
+
+export interface CalendarState {
+  date: Date
+  view: View
+  setDate: (date: Date) => void
+  setView: (view: View) => void
+}
+
+export const CalendarContext = createContext<CalendarState | undefined>(undefined)
+

--- a/src/calendar/CalendarProvider.tsx
+++ b/src/calendar/CalendarProvider.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react'
+import { CalendarContext } from './CalendarContext'
+import type { View } from './CalendarContext'
+
+export default function CalendarProvider({ children }: { children: React.ReactNode }) {
+  const [date, setDate] = useState(new Date())
+  const [view, setView] = useState<View>('daily')
+
+  return (
+    <CalendarContext.Provider value={{ date, view, setDate, setView }}>
+      {children}
+    </CalendarContext.Provider>
+  )
+}
+

--- a/src/calendar/DateNavigator.tsx
+++ b/src/calendar/DateNavigator.tsx
@@ -1,0 +1,30 @@
+import useCalendar from './useCalendar'
+
+export default function DateNavigator() {
+  const { date, setDate, view } = useCalendar()
+
+  const increment = () => {
+    const newDate = new Date(date)
+    if (view === 'daily') newDate.setDate(newDate.getDate() + 1)
+    if (view === 'weekly') newDate.setDate(newDate.getDate() + 7)
+    if (view === 'monthly') newDate.setMonth(newDate.getMonth() + 1)
+    setDate(newDate)
+  }
+
+  const decrement = () => {
+    const newDate = new Date(date)
+    if (view === 'daily') newDate.setDate(newDate.getDate() - 1)
+    if (view === 'weekly') newDate.setDate(newDate.getDate() - 7)
+    if (view === 'monthly') newDate.setMonth(newDate.getMonth() - 1)
+    setDate(newDate)
+  }
+
+  return (
+    <div>
+      <button onClick={decrement}>{'<'}</button>
+      <span>{date.toDateString()}</span>
+      <button onClick={increment}>{'>'}</button>
+    </div>
+  )
+}
+

--- a/src/calendar/ViewSwitcher.tsx
+++ b/src/calendar/ViewSwitcher.tsx
@@ -1,0 +1,20 @@
+import useCalendar from './useCalendar'
+
+export default function ViewSwitcher() {
+  const { view, setView } = useCalendar()
+
+  return (
+    <div>
+      <button onClick={() => setView('daily')} disabled={view === 'daily'}>
+        Daily
+      </button>
+      <button onClick={() => setView('weekly')} disabled={view === 'weekly'}>
+        Weekly
+      </button>
+      <button onClick={() => setView('monthly')} disabled={view === 'monthly'}>
+        Monthly
+      </button>
+    </div>
+  )
+}
+

--- a/src/calendar/useCalendar.ts
+++ b/src/calendar/useCalendar.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react'
+import { CalendarContext } from './CalendarContext'
+
+export default function useCalendar() {
+  const ctx = useContext(CalendarContext)
+  if (!ctx) throw new Error('useCalendar must be used within CalendarProvider')
+  return ctx
+}
+

--- a/src/calendar/views/DailyView.tsx
+++ b/src/calendar/views/DailyView.tsx
@@ -1,0 +1,7 @@
+import useCalendar from '../useCalendar'
+
+export default function DailyView() {
+  const { date } = useCalendar()
+  return <div>Daily view for {date.toDateString()}</div>
+}
+

--- a/src/calendar/views/MonthlyView.tsx
+++ b/src/calendar/views/MonthlyView.tsx
@@ -1,0 +1,7 @@
+import useCalendar from '../useCalendar'
+
+export default function MonthlyView() {
+  const { date } = useCalendar()
+  return <div>Monthly view for {date.toDateString()}</div>
+}
+

--- a/src/calendar/views/WeeklyView.tsx
+++ b/src/calendar/views/WeeklyView.tsx
@@ -1,0 +1,7 @@
+import useCalendar from '../useCalendar'
+
+export default function WeeklyView() {
+  const { date } = useCalendar()
+  return <div>Weekly view starting {date.toDateString()}</div>
+}
+

--- a/src/pages/Calendario.tsx
+++ b/src/pages/Calendario.tsx
@@ -1,0 +1,30 @@
+import CalendarProvider from '../calendar/CalendarProvider'
+import useCalendar from '../calendar/useCalendar'
+import DateNavigator from '../calendar/DateNavigator'
+import ViewSwitcher from '../calendar/ViewSwitcher'
+import DailyView from '../calendar/views/DailyView'
+import WeeklyView from '../calendar/views/WeeklyView'
+import MonthlyView from '../calendar/views/MonthlyView'
+
+function CalendarViews() {
+  const { view } = useCalendar()
+  switch (view) {
+    case 'weekly':
+      return <WeeklyView />
+    case 'monthly':
+      return <MonthlyView />
+    default:
+      return <DailyView />
+  }
+}
+
+export default function Calendario() {
+  return (
+    <CalendarProvider>
+      <ViewSwitcher />
+      <DateNavigator />
+      <CalendarViews />
+    </CalendarProvider>
+  )
+}
+


### PR DESCRIPTION
## Summary
- introduce calendar provider with view switching and date navigation
- add placeholder dependencies for upcoming calendar feature
- expose `/calendario` route and document initial skeleton

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c9a43e96083339d8ff95cb4cdd330